### PR TITLE
feat : update site icon to geometric cluster design

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,1 +1,35 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="48" height="46" fill="none" viewBox="0 0 48 46"><path fill="#863bff" d="M25.946 44.938c-.664.845-2.021.375-2.021-.698V33.937a2.26 2.26 0 0 0-2.262-2.262H10.287c-.92 0-1.456-1.04-.92-1.788l7.48-10.471c1.07-1.497 0-3.578-1.842-3.578H1.237c-.92 0-1.456-1.04-.92-1.788L10.013.474c.214-.297.556-.474.92-.474h28.894c.92 0 1.456 1.04.92 1.788l-7.48 10.471c-1.07 1.498 0 3.579 1.842 3.579h11.377c.943 0 1.473 1.088.89 1.83L25.947 44.94z" style="fill:#863bff;fill:color(display-p3 .5252 .23 1);fill-opacity:1"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" rx="96" fill="#1a1530"/>
+  <g stroke="#863bff" stroke-width="2" opacity="0.4" fill="none">
+    <line x1="256" y1="256" x2="160" y2="160"/>
+    <line x1="256" y1="256" x2="360" y2="150"/>
+    <line x1="256" y1="256" x2="380" y2="320"/>
+    <line x1="256" y1="256" x2="170" y2="370"/>
+    <line x1="256" y1="256" x2="380" y2="400"/>
+  </g>
+  <polygon points="256,180 322,218 322,294 256,332 190,294 190,218" fill="#fbbf24"/>
+  <polygon points="256,200 305,228 305,284 256,312 207,284 207,228" fill="#fef3c7"/>
+  <circle cx="256" cy="256" r="10" fill="#fbbf24"/>
+  <g transform="translate(160 160)">
+    <polygon points="0,-26 22,12 -22,12" fill="#a26bff"/>
+    <circle cx="0" cy="-2" r="5" fill="#1a1530"/>
+  </g>
+  <g transform="translate(360 150)">
+    <polygon points="0,-28 26,0 0,28 -26,0" fill="#ff6b9d"/>
+    <circle cx="0" cy="0" r="6" fill="#1a1530"/>
+  </g>
+  <g transform="translate(380 320)">
+    <ellipse cx="0" cy="0" rx="30" ry="20" fill="#6ee7b7"/>
+    <line x1="-18" y1="-15" x2="-18" y2="15" stroke="#1a1530" stroke-width="2" opacity="0.4"/>
+    <line x1="-2" y1="-18" x2="-2" y2="18" stroke="#1a1530" stroke-width="2" opacity="0.4"/>
+    <line x1="14" y1="-15" x2="14" y2="15" stroke="#1a1530" stroke-width="2" opacity="0.4"/>
+  </g>
+  <g transform="translate(170 370)">
+    <path d="M -22 -10 Q -28 14 -8 22 Q 18 26 24 6 Q 28 -16 6 -22 Q -16 -22 -22 -10 Z" fill="#a26bff"/>
+    <circle cx="-2" cy="-2" r="4" fill="#1a1530"/>
+  </g>
+  <g transform="translate(380 400)">
+    <circle cx="0" cy="0" r="22" fill="none" stroke="#ff6b9d" stroke-width="10"/>
+    <circle cx="0" cy="0" r="6" fill="#ff6b9d"/>
+  </g>
+</svg>


### PR DESCRIPTION
Replace the previous purple lightning favicon with a flat-design icon showing the host nucleus surrounded by geometric parasites — visually aligned with the project's "host vs. dependencies" core concept.